### PR TITLE
Added check for length in token compare

### DIFF
--- a/json.h
+++ b/json.h
@@ -435,6 +435,7 @@ json_lcmp(const struct json_token* tok, const char* str, int len)
     JSON_ASSERT(tok);
     JSON_ASSERT(str);
     if (!tok || !str || !len) return 1;
+	if(tok->len != len) return 1;
     for (i = 0; (i < tok->len && i < len); i++, str++){
         if (tok->str[i] != *str)
             return 1;

--- a/json.h
+++ b/json.h
@@ -435,7 +435,7 @@ json_lcmp(const struct json_token* tok, const char* str, int len)
     JSON_ASSERT(tok);
     JSON_ASSERT(str);
     if (!tok || !str || !len) return 1;
-	if(tok->len != len) return 1;
+    if (tok->len != len) return 1;
     for (i = 0; (i < tok->len && i < len); i++, str++){
         if (tok->str[i] != *str)
             return 1;


### PR DESCRIPTION
Fixes a bug where multiple tokens that start with the same character sequence are not queried correctly.