### PR TITLE
Add missing #endif.

### DIFF
--- a/vec.h
+++ b/vec.h
@@ -1879,3 +1879,4 @@ xq_from_mat3(float *q, const float *m)
     #undef M
 }
 
+#endif


### PR DESCRIPTION
Not sure why this wasn't noted yet, but at least with Visual Studio this causes compiler errors.