### PR TITLE
Fix lexer_read_on_line returning empty tokens at EOF

### DIFF
--- a/lexer.h
+++ b/lexer.h
@@ -1332,6 +1332,7 @@ lexer_read_on_line(struct lexer *lexer, struct lexer_token *token)
     if (!lexer_read(lexer, &tok)) {
         lexer->current = lexer->last;
         lexer->line = lexer->last_line;
+        return 0;
     }
     if (!tok.line_crossed) {
         *token = tok;


### PR DESCRIPTION
At EOF, `lexer_read()` returns 0 and an empty token.
While this is supposedly taken care of by the if statement it is called in, the statement falls through and reaches the following `if (!tok.line_crossed)` which may evaluate to true (UB due to line_crossed being uninitialized) and consequently return empty tokens indefinitely.

This PR/commit fixes that by returning early.

Most likely an oversight really.