### PR TITLE
Fix address overflow issue in web.h for 64 builds.

### DIFF
--- a/web.h
+++ b/web.h
@@ -170,7 +170,13 @@ extern "C" {
 #endif
 #else
 #ifndef WBY_UINT_PTR
+
+#if defined(__i386__) || (!defined(_WIN64) && defined(_WIN32))
 #define WBY_UINT_PTR unsigned long
+#else
+#define WBY_UINT_PTR unsigned long long
+#endif
+
 #endif
 #endif
 typedef unsigned char wby_byte;


### PR DESCRIPTION
Slight change to avoid overflows in address pointers on 64 bit. I very much like this software, btw.  There is a huge shortage of simple, no-BS, zero-dep software and I think this project is great. Thanks for the quality code.