### PR TITLE
sched memory leak on unjoined pthreads.

### DIFF
--- a/sched.h
+++ b/sched.h
@@ -534,7 +534,8 @@ sched_thread_create(sched_thread *returnid, void*(*StartFunc)(void*), void *arg)
 SCHED_INTERN sched_int
 sched_thread_term(sched_thread threadid)
 {
-    return (pthread_cancel(threadid) == 0);
+    pthread_cancel(threadid);
+    return (pthread_join(threadid, NULL) == 0);
 }
 
 SCHED_INTERN sched_uint


### PR DESCRIPTION
pthread memory leak fix for unjoined Zombie threads if scheduler is repeatedly shutdown and restarted (threads aren't joined).
I know repeatedly restarting the scheduler is against its intended design, but the thread stacks are leaked and can't be reclaimed by the OS.