### PR TITLE
json: Fix a disjointed update of a token's pointer and length in json_deq()

### DIFF
--- a/json.h
+++ b/json.h
@@ -851,7 +851,7 @@ JSON_API struct json_iter
 json_begin(const char *str, int len)
 {
     struct json_iter iter = JSON_ITER_NULL;
-    iter.src = str; iter.len = len;
+    iter.src = str, iter.len = len;
     return iter;
 }
 JSON_API struct json_iter
@@ -958,7 +958,7 @@ json_read(struct json_token *obj, const struct json_iter* prev)
                 iter.src = cur;
                 iter.len = len;
                 return iter;
-            } cur--; len++;
+            } cur--, len++;
         } break;
         case JSON_STATE_UTF8_2: {
             iter.go = json_go_utf8;
@@ -1230,7 +1230,7 @@ json_query(struct json_token *toks, int count, const char *path)
                 array.len = 0;
 
                 /* iterate over each array element and find the correct index */
-                iter++; i++;
+                iter++, i++;
                 for (j = 0; j < n; ++j) {
                     if (iter->type == JSON_ARRAY || iter->type == JSON_OBJECT) {
                         i = i + (iter->sub) + 1;


### PR DESCRIPTION
Fix an obvious typo: In a clear contradiction with the intent, in the paired update of the token pointer and length fields in `json_deq()`, it is only the former that is guarded by the if statement.

To make sure that this is the only occurrence of this bug, I inspected all other places in json.h where a similar joint update happens on a single line, and propose to also consistently use single statements for all of them (like it is already done on [line 985] here and in many places in sdefl.h and sinfl.h, for example).

[line 985]: https://github.com/vurtun/lib/blob/3fbeb102f4ddef8bf0d3420321ac4105eb9fa52f/json.h#L985