### PR TITLE
[sdefl, sinfl] Solve identifier '_BitScanReverse' not found problems

### DIFF
--- a/sdefl.h
+++ b/sdefl.h
@@ -180,6 +180,10 @@ extern int zsdeflate(struct sdefl *s, void *o, const void *i, int n, int lvl);
 #include <string.h> /* memcpy */
 #include <limits.h> /* CHAR_BIT */
 
+#ifdef _MSC_VER
+#include <intrin.h> /* _BitScanReverse */
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sinfl.h
+++ b/sinfl.h
@@ -142,6 +142,10 @@ extern int zsinflate(void *out, int cap, const void *in, int size);
 #include <string.h> /* memcpy, memset */
 #include <assert.h> /* assert */
 
+#ifdef _MSC_VER
+#include <intrin.h> /* _BitScanReverse */
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
When the project uses the VS2017 tool set, the following error will be reported:
```
sinfl.h(179): error C3861: '_BitScanReverse': identifier not found
sdefl.h(207): error C3861: '_BitScanReverse': identifier not found
```
A higher version of the MSVC compiler may indirectly include the <intrin.h> header file, but the lower version still needs to include it explicitly.
