### PR TITLE
[sdefl] Fix bug where some members of struct sdefl are not initialized

### DIFF
--- a/sdefl.h
+++ b/sdefl.h
@@ -673,6 +673,9 @@ sdefl_compr(struct sdefl *s, unsigned char *out, const unsigned char *in,
   for (n = 0; n < SDEFL_HASH_SIZ; ++n) {
     s->tbl[n] = SDEFL_NIL;
   }
+  s->seq_cnt = 0;
+  memset(&s->freq, 0, sizeof(sdefl_freq));
+
   do {int blk_begin = i;
     int blk_end = ((i + SDEFL_BLK_MAX) < in_len) ? (i + SDEFL_BLK_MAX) : in_len;
     while (i < blk_end) {


### PR DESCRIPTION
Some members of the sdefl structure have not been initialized. If you initialize the entire sdefl structure to 0 externally, the cost will be very high. You know, the size of the sdefl structure is nearly 1 MB. All we need to do is to initialize the key members internally. Is my revision correct?