### PR TITLE
[sinfl] Reduce unnecessary memcpy when memory does not overlap

### DIFF
--- a/sinfl.h
+++ b/sinfl.h
@@ -190,9 +190,7 @@ sinfl_read64(const void *p) {
 }
 static void
 sinfl_copy64(unsigned char **dst, unsigned char **src) {
-  unsigned long long n;
-  memcpy(&n, *src, 8);
-  memcpy(*dst, &n, 8);
+  memcpy(*dst, *src, 8);
   *dst += 8, *src += 8;
 }
 static unsigned char*


### PR DESCRIPTION
sinfl_copy64 has already ensured that the memory will not overlap before being called, so there is no need to first copy the memory to a temporary buffer before copying it to the target memory.

```cpp
/* note: src = dst - offs */
if (offs >= 8) {
    /* word copy match */
    sinfl_copy64(&dst, &src);
    sinfl_copy64(&dst, &src);
    do sinfl_copy64(&dst, &src);
    while (dst < out);
}
```
